### PR TITLE
Improve failed_when rule for Wordpress Installed check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
   register: initialize_after_wp_installed
   when: initialize_after_current_path.stat.exists
   changed_when: false
-  failed_when: initialize_after_wp_installed.stderr != ""
+  failed_when: initialize_after_wp_installed.stderr | default("") != "" or wp_installed.rc > 1
 
 - name: Backup WordPress database
   command: wp db export


### PR DESCRIPTION
To keep in sync with [roots/trellis#991](https://github.com/roots/trellis/pull/991).